### PR TITLE
Open API example code in CodePen

### DIFF
--- a/map-sdk/v1/js/api/create-map/index.html
+++ b/map-sdk/v1/js/api/create-map/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<title>Unfolded Map SDK - createMap example</title>
+<link href="https://foursquare.github.io/unfolded-sdk-examples/src/common/examples.css" rel="stylesheet" />
+</head>
+<body>
+<div id="codepen"></div>
+<div id="map"></div>
+<script id="script" type="module">
+import {createMap} from 'https://unpkg.com/@unfolded/map-sdk@1.2.0';
+
+const map = await createMap({
+  container: document.querySelector('#map')
+});
+</script>
+<script>
+addToCodePen();
+
+function addToCodePen() {
+  let htmlString = document.getElementById('script').innerHTML;
+  htmlString = htmlString.replace(/"/g, '&​quot;').replace(/'/g, '&apos;');
+  const JSONstring = JSON.stringify({
+    title: 'Map SDK - Create Map',
+    html: '&lt;div id="map"&gt;&lt;/div&gt;',
+    css: 'html,body {height: 100%;}body {overflow: hidden;margin: 0px;}',
+    js: htmlString,
+    js_pre_processor: 'none',
+    js_modernizr: false
+  });
+
+  const form =
+    '<form action="https://codepen.io/pen/define" method="POST" target="_blank">' +
+    '<input type="hidden" name="data" value=\'' +
+    JSONstring +
+    "'>" +
+    '<input type="image" src="http://s.cdpn.io/3/cp-arrow-right.svg" style="z-index: 1; position: fixed; top: 20px; left: 50%; transform: translateY(-50%);" width="40" height="40" value="Create New Pen with Prefilled Data" class="codepen-mover-button">' +
+    '</form>';
+
+  document.getElementById('codepen').innerHTML += form;
+}
+</script>
+</body>
+</html>


### PR DESCRIPTION
The idea behind this PR is to allow developers using our SDK to be able to open the example on CodePen, without making any modifications to the html or js that are specific for the CodePen API.

Using this approach we can support both `Open in GitHub` and `Open in CodePen` badges at the top with one codebase, with clean code. The idea is to embed these small examples in our API functions documentation pages.

This `addToCodePen` function will be moved to another file that our examples can call. There we can escape characters for `html` and `js` code that is needed for this to work with CodePen and it won't have any effect on our code so that our examples are always functional and free of any CodePen specific code.

There are a couple of flaws (but those are limitations in CodePen):
- We need to make sure everything is escaped properly (in this helper function) but this shouldn't be a big problem as these examples should be simple and they should illustrate how a single API function works
- The code shouldn't be indented along with the whole html, but start from row 1, as it will look weird in CodePen

Preview (feel free to test the html yourself):

![codepen](https://user-images.githubusercontent.com/7241522/191622286-71fcbc77-b258-476c-b884-18ccc08ec5fc.gif)
