### PR TITLE
fix(examples): remove print statement

### DIFF
--- a/notebooks/06 - Crossfilter.ipynb
+++ b/notebooks/06 - Crossfilter.ipynb
@@ -214,7 +214,6 @@
    "source": [
     "def on_map_filter_change(event_info):\n",
     "    # Update the selection in the histogram\n",
-    "    print(event_info)\n",
     "    if 'magnitude_filter' in event_info['id']:\n",
     "        v = event_info['value']\n",
     "        hist_fig.update_selections(dict(x0=v[0], x1=v[1],y0=0, y1=9000))\n",


### PR DESCRIPTION
this was causing the print statements to show up on the map itself in colab